### PR TITLE
fix: Redesign card content to show a snippet

### DIFF
--- a/projects.js
+++ b/projects.js
@@ -48,13 +48,15 @@ document.addEventListener("DOMContentLoaded", () => {
                         const mdResponse = await fetch(item.file);
                         if (mdResponse.ok) {
                             const markdown = await mdResponse.text();
-                            description = marked.parse(markdown);
+                            // Create a snippet instead of full parsed markdown
+                            const snippet = markdown.replace(/#.*$/m, '').trim().substring(0, 150) + '...';
+                            description = `<p>${snippet}</p>`; // Wrap snippet in a p tag for consistent styling
                         } else {
                             throw new Error(`Failed to load ${item.file}`);
                         }
                     } catch (error) {
                         console.error("Error loading markdown file:", error);
-                        description = "Error loading content.";
+                        description = "<p>Error loading content.</p>";
                     }
                 }
 

--- a/script.js
+++ b/script.js
@@ -148,13 +148,15 @@ document.addEventListener("DOMContentLoaded", () => {
                         const mdResponse = await fetch(item.file);
                         if (mdResponse.ok) {
                             const markdown = await mdResponse.text();
-                            description = marked.parse(markdown);
+                            // Create a snippet instead of full parsed markdown
+                            const snippet = markdown.replace(/#.*$/m, '').trim().substring(0, 150) + '...';
+                            description = `<p>${snippet}</p>`; // Wrap snippet in a p tag for consistent styling
                         } else {
                             throw new Error(`Failed to load ${item.file}`);
                         }
                     } catch (error) {
                         console.error("Error loading markdown file:", error);
-                        description = "Error loading content.";
+                        description = "<p>Error loading content.</p>";
                     }
                 }
 

--- a/styles.css
+++ b/styles.css
@@ -220,20 +220,20 @@ footer .social-links a:hover {
     left: 100%;
     width: 100%;
     height: 100%;
-    padding: 1rem;
+    padding: 1.5rem;
     background-color: #1e1e1e;
     color: #ccc;
     opacity: 0;
     visibility: hidden;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    text-align: left;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
 }
 
 .card-content div {
-    max-height: 70%;
-    overflow-y: auto;
+    /* This div now just holds the snippet paragraph */
 }
 
 .card.open .card-front {
@@ -254,12 +254,14 @@ footer .social-links a:hover {
     text-decoration: none;
     color: white;
     border-radius: 4px;
-    align-self: flex-start;
+    align-self: center;
    }
 
    .card-content p {
     margin-bottom: 1rem;
     color: #f0f0f0;
+    font-size: 0.9rem;
+    line-height: 1.6;
    }
 
 


### PR DESCRIPTION
This commit redesigns the content on the back of the portfolio cards based on user feedback.

Key changes include:
- **Snippet instead of Full Content:** The cards now display a short, plain-text snippet of the project or blog post description instead of the full content. This provides a cleaner and more concise preview.
- **No Scrolling:** The scrolling behavior on the back of the cards has been removed.
- **Improved Layout:** The styling of the card content has been updated to better display the snippet and the "Read More" link. The logic has been applied to both the index page and the dedicated projects page for consistency.